### PR TITLE
Enabling creation of DBML diagrams for the DB schema

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,4 @@ zope.interface==7.2
 pytest
 pytest-asyncio
 pytest-django
+django-dbml

--- a/src/monitor_app/models.py
+++ b/src/monitor_app/models.py
@@ -56,7 +56,7 @@ class AppLog(models.Model):
         ordering = ['-timestamp']
         verbose_name_plural = "App Logs"
         indexes = [
-            models.Index(fields=['-timestamp', 'app_name', 'instance_name']),
+            models.Index(fields=['timestamp', 'app_name', 'instance_name']),
         ]
 
     def __str__(self):

--- a/src/swf_monitor_project/settings.py
+++ b/src/swf_monitor_project/settings.py
@@ -59,6 +59,7 @@ INSTALLED_APPS = [
     "drf_spectacular",
     "rest_framework.authtoken",
     "django_seed",
+    "django_dbml"
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
Suggestion to add `django-dbml` for generating diagrams of the DB schema. It can be used as 
```shell
python ./src/manage.py dbml > diagram.dbml 
```
And use https://dbdiagram.io/ or a [VSCode extension for dbml](https://marketplace.visualstudio.com/items?itemName=matt-meyers.vscode-dbml). 

<img width="1659" height="1130" alt="image" src="https://github.com/user-attachments/assets/3c406e7e-441b-4ab5-bd92-31714500b094" />


This also requires to remove the prefix `-` at:
```python
            models.Index(fields=['timestamp', 'app_name', 'instance_name']),
```
for Django DBML handling properly the index. Since the ordering is explicity defined at `ordering = ['-timestamp']`, I understand it shoud have no impact.

