### PR TITLE
Add GitHub Action that verifies operability against swf-monitor

### DIFF
--- a/.github/workflows/swf-monitor-ci.yml
+++ b/.github/workflows/swf-monitor-ci.yml
@@ -11,4 +11,5 @@ jobs:
     uses: BNLNPPS/swf-testbed/.github/workflows/integration-test.yml@main
     with:
       swf_testbed_ref: main
+      swf_monitor_repo: ${{ github.repository }}
       swf_monitor_ref: ${{ github.sha }}

--- a/.github/workflows/swf-monitor-ci.yml
+++ b/.github/workflows/swf-monitor-ci.yml
@@ -1,0 +1,14 @@
+name: swf-monitor CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  integration-test:
+    uses: BNLNPPS/swf-testbed/.github/workflows/integration-test.yml@main
+    with:
+      swf_testbed_ref: main
+      swf_monitor_ref: ${{ github.sha }}


### PR DESCRIPTION
This should help to prevent regressions.

Needs infra/baseline-37 merged first.