### PR TITLE
Integration image installs swf-epicprod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,14 @@ RUN pip install --no-cache-dir django-mcp-server django-oauth-toolkit uvicorn
 COPY . /build/swf-monitor
 RUN pip install --no-cache-dir -e /build/swf-monitor
 
+# Clone and install swf-epicprod (production applications installed into the
+# monitor runtime; provides the pcs package in INSTALLED_APPS). Same
+# self-contained pattern as swf-common-lib above.
+ARG SWF_EPICPROD_REF=main
+RUN git clone --depth 1 --branch "${SWF_EPICPROD_REF}" \
+        https://github.com/BNLNPPS/swf-epicprod.git /build/swf-epicprod \
+    && pip install --no-cache-dir /build/swf-epicprod
+
 # Collect static files.  We set only the variables that settings.py requires at
 # import time; the real values come from the environment at runtime.
 RUN SECRET_KEY="build-placeholder" \


### PR DESCRIPTION
The v38 baseline moved the pcs application to swf-epicprod; the monitor image build did not install it, so the container failed at Django startup with `No module named 'pcs'` — caught by the operability check on the v38 merge (run 29123511239). The build stage now clones and installs swf-epicprod with a `SWF_EPICPROD_REF` build-arg, following the existing swf-common-lib pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)