### PR TITLE
Schema diagram workflow: working generation, change-gated commits

### DIFF
--- a/.github/workflows/schema-diagram.yml
+++ b/.github/workflows/schema-diagram.yml
@@ -1,36 +1,37 @@
 name: Generate Schema Diagram
 
+# Regenerate testbed-schema.dbml on every main push; the commit step is
+# the change test — the generator's timestamp line is stripped, so an
+# unchanged schema produces no diff and no commit.
 on:
   push:
-    paths:
-      - 'src/monitor_app/models.py'
-      - 'src/mcp_app/models.py'
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
   generate-schema:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v3
-    
+    - uses: actions/checkout@v4
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: '3.11'
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install --no-cache-dir -r requirements.txt
-    
-    - name: Debug environment
-      run: |
-        echo "Current commit SHA: ${{ github.sha }}"
-        echo "DJANGO_LOGGING_MODE will be set to: none"
-        cd src
-        python -c "import os; print(f'Python sees DJANGO_LOGGING_MODE={os.getenv(\"DJANGO_LOGGING_MODE\", \"NOT SET\")}')"
-    
+        # INSTALLED_APPS packages that ship outside requirements.txt
+        # (same set the Dockerfile installs), and the sibling repos:
+        # swf-common-lib and swf-epicprod (the pcs application).
+        pip install --no-cache-dir django-oauth-toolkit django-mcp-server uvicorn
+        pip install --no-cache-dir \
+          git+https://github.com/BNLNPPS/swf-common-lib.git \
+          git+https://github.com/BNLNPPS/swf-epicprod.git
+
     - name: Generate DBML schema
       env:
         SECRET_KEY: 'github-actions-dummy-key-for-schema-generation'
@@ -40,17 +41,18 @@ jobs:
         DB_HOST: 'localhost'
         DJANGO_LOGGING_MODE: 'none'
       run: |
-        echo "DJANGO_LOGGING_MODE=$DJANGO_LOGGING_MODE"
-        cd src
-        python manage.py dbml > ../testbed-schema.dbml
-    
+        # The wrapper works around django-dbml's KeyError on index
+        # fields declared with a descending prefix.
+        python scripts/generate-schema-dbml.py > testbed-schema.dbml
+        sed -i '/Last Updated At/d' testbed-schema.dbml
+
     - name: Commit schema if changed
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add testbed-schema.dbml
         git diff --staged --quiet || git commit -m "Update database schema diagram"
-    
+
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:

--- a/scripts/generate-schema-dbml.py
+++ b/scripts/generate-schema-dbml.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Generate the database schema DBML to stdout.
+
+Wraps django-dbml's management command with a workaround: the library
+(1.1.2) looks index fields up verbatim, so an index declared with a
+descending field ('-timestamp_created') raises KeyError. The ordering
+prefix is stripped from every model index before generation — the
+diagram loses only the sort direction.
+
+Usage: python scripts/generate-schema-dbml.py > testbed-schema.dbml
+(the workflow also strips the generator's Last-Updated timestamp line
+so an unchanged schema produces no diff).
+"""
+import os
+import sys
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(THIS_DIR, '..', 'src'))
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'swf_monitor_project.settings')
+
+import django  # noqa: E402
+django.setup()
+
+from django.apps import apps  # noqa: E402
+from django.core.management import call_command  # noqa: E402
+
+for model in apps.get_models():
+    for index in model._meta.indexes:
+        index.fields = [f.lstrip('-') for f in index.fields]
+
+call_command('dbml')


### PR DESCRIPTION
The workflow has been red on every trigger: settings import fails (`No module named 'oauth2_provider'` — INSTALLED_APPS packages outside requirements.txt), django-dbml 1.1.2 raises KeyError on index fields with a descending prefix, and the generator's embedded timestamp made every run diff even with an unchanged schema.

- The install step adds the extras the Dockerfile installs, plus swf-common-lib and swf-epicprod (the pcs application) from GitHub.
- `scripts/generate-schema-dbml.py` wraps generation, stripping the ordering prefix from model index fields before django-dbml reads them.
- The timestamp line is stripped from the output, so the commit-if-changed step is a true change test.
- Trigger: pushes to main plus workflow_dispatch (previously any-branch pushes touching models.py, which can no longer see pcs model changes anyway).

First run after merge will commit a genuinely updated schema (the committed dbml predates the pcs move and the v36-v38 model changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)